### PR TITLE
HOTFIX: Edited setup.py to require 'oauth2client' explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 """Upload videos to Youtube."""
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup_kwargs = {
     "name": "youtube-upload",
@@ -31,7 +34,8 @@ setup_kwargs = {
     },
     "install_requires":[
         'google-api-python-client',
-        'progressbar2'
+        'progressbar2',
+        'oauth2client'
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 """Upload videos to Youtube."""
+import sys
 try:
     from setuptools import setup
 except ImportError:
-    from distutils.core import setup
+    sys.exit("setuptools is required for building youtube-upload")
 
 setup_kwargs = {
     "name": "youtube-upload",


### PR DESCRIPTION
Fix to address the [upload script](https://github.com/edgi-govdata-archiving/edgi-scripts) breaking in [CircleCI.](https://circleci.com/gh/edgi-govdata-archiving/edgi-scripts/18222) 

The `oauth2client` module was missing from this sub-dependency repo, not sure why, so I added it explicitly to `setup.py`.

I also imported `setuptools` because I was running into this [problem](https://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package) when installing locally.

@danielballan Can you take a look and merge if this makes sense? I don't have write access to this repo and the little I know about python setup was what I just googled  this morning.