### PR TITLE
Added --license option to set the video license.

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -125,6 +125,7 @@ def upload_youtube_video(youtube, options, video_path, total_videos, index):
         "status": {
             "privacyStatus": ("private" if options.publish_at else options.privacy),
             "publishAt": options.publish_at,
+            "license": options.license,
 
         },
         "recordingDetails": {
@@ -212,6 +213,9 @@ def main(arguments):
         default="public", help='Privacy status (public | unlisted | private)')
     parser.add_option('', '--publish-at', dest='publish_at', metavar="datetime",
        default=None, help='Publish date (ISO 8601): YYYY-MM-DDThh:mm:ss.sZ')
+    parser.add_option('', '--license', dest='license', metavar="string",
+       choices=('youtube', 'creativeCommon'), default='youtube',
+       help='License for the video, either "youtube" (the default) or "creativeCommon"')
     parser.add_option('', '--location', dest='location', type="string",
         default=None, metavar="latitude=VAL,longitude=VAL[,altitude=VAL]",
         help='Video location"')


### PR DESCRIPTION
Merging this into master because CircleCI installation requirements is pointed at `add-license-option` branch but we would need to use `master` where necessary changes are made. This way we can point to `master` in CircleCI instead.